### PR TITLE
Improve cross-platform UltraDES setup

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,52 +1,169 @@
-import setuptools
-import os
+"""Packaging helpers for UltraDES-Python.
 
-# Lê a descrição longa a partir do arquivo README.md
-with open("README.md", "r") as fh:
+The Python wrapper needs the managed UltraDES assembly.  During build we try to
+fetch the newest UltraDES package from NuGet and copy its DLL into the Python
+package.  If the network is unavailable (common in some CI/offline notebooks),
+the repository-bundled DLL is kept as a fallback.
+"""
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+import re
+import shutil
+import tempfile
+import urllib.request
+import zipfile
+
+import setuptools
+from setuptools.command.build_py import build_py as _build_py
+
+PACKAGE_DIR = Path(__file__).parent / "ultrades"
+ASSEMBLY_NAME = "UltraDES.dll"
+NUGET_PACKAGE_ID = os.environ.get("ULTRADES_NUGET_PACKAGE", "UltraDES")
+NUGET_VERSION = os.environ.get("ULTRADES_NUGET_VERSION")
+NUGET_FLAT_CONTAINER = "https://api.nuget.org/v3-flatcontainer"
+
+
+def _version_key(version: str) -> tuple:
+    """Return a sortable key for NuGet semantic versions without extra deps."""
+
+    public_version = version.split("+", 1)[0]
+    release, separator, prerelease = public_version.partition("-")
+    release_key = tuple(int(part) if part.isdigit() else part for part in release.split("."))
+    prerelease_key = tuple(
+        int(part) if part.isdigit() else part.lower()
+        for part in re.split(r"[.-]", prerelease)
+        if part
+    )
+    return (release_key, separator == "", prerelease_key)
+
+
+def _read_json(url: str) -> dict:
+    request = urllib.request.Request(url, headers={"User-Agent": "UltraDES-Python setup.py"})
+    with urllib.request.urlopen(request, timeout=30) as response:
+        return json.loads(response.read().decode("utf-8"))
+
+
+def _latest_nuget_version(package_id: str) -> str:
+    index_url = f"{NUGET_FLAT_CONTAINER}/{package_id.lower()}/index.json"
+    versions = _read_json(index_url).get("versions", [])
+    if not versions:
+        raise RuntimeError(f"No NuGet versions found for {package_id!r}")
+    return sorted(versions, key=_version_key)[-1]
+
+
+def _select_assembly(candidates: list[str]) -> str:
+    """Choose the most portable UltraDES.dll from a NuGet package."""
+
+    preferred_frameworks = (
+        "netstandard2.0",
+        "netstandard2.1",
+        "net8.0",
+        "net7.0",
+        "net6.0",
+        "net5.0",
+        "netcoreapp",
+        "net48",
+        "net472",
+        "net461",
+        "net45",
+    )
+
+    def score(path: str) -> tuple[int, int, str]:
+        lowered = path.lower().replace("\\", "/")
+        framework_score = next(
+            (index for index, framework in enumerate(preferred_frameworks) if f"/{framework}" in lowered),
+            len(preferred_frameworks),
+        )
+        # Prefer lib/ assemblies over build/analyzers/tools content.
+        location_score = 0 if lowered.startswith("lib/") else 1
+        return (framework_score, location_score, lowered)
+
+    return sorted(candidates, key=score)[0]
+
+
+def download_ultrades_from_nuget(destination: Path) -> str:
+    """Download UltraDES.dll from NuGet into *destination* and return version."""
+
+    package_id = NUGET_PACKAGE_ID
+    version = NUGET_VERSION or _latest_nuget_version(package_id)
+    package_url = (
+        f"{NUGET_FLAT_CONTAINER}/{package_id.lower()}/{version.lower()}/"
+        f"{package_id.lower()}.{version.lower()}.nupkg"
+    )
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        nupkg_path = Path(tmpdir) / f"{package_id}.{version}.nupkg"
+        request = urllib.request.Request(package_url, headers={"User-Agent": "UltraDES-Python setup.py"})
+        with urllib.request.urlopen(request, timeout=60) as response:
+            nupkg_path.write_bytes(response.read())
+
+        with zipfile.ZipFile(nupkg_path) as archive:
+            candidates = [
+                name
+                for name in archive.namelist()
+                if name.replace("\\", "/").lower().endswith(f"/{ASSEMBLY_NAME.lower()}")
+            ]
+            if not candidates:
+                raise RuntimeError(f"{ASSEMBLY_NAME} was not found in {package_id} {version}")
+            selected = _select_assembly(candidates)
+            destination.parent.mkdir(parents=True, exist_ok=True)
+            with archive.open(selected) as source, destination.open("wb") as target:
+                shutil.copyfileobj(source, target)
+    return version
+
+
+class build_py(_build_py):
+    """Download the current UltraDES assembly before building Python modules."""
+
+    def run(self) -> None:
+        destination = PACKAGE_DIR / ASSEMBLY_NAME
+        if os.environ.get("ULTRADES_SKIP_NUGET_DOWNLOAD") == "1":
+            self.announce("Skipping UltraDES NuGet download by request", level=2)
+        else:
+            try:
+                version = download_ultrades_from_nuget(destination)
+                self.announce(f"Downloaded {NUGET_PACKAGE_ID} {version} from NuGet", level=2)
+            except Exception as exc:
+                if not destination.exists():
+                    raise RuntimeError(
+                        "Unable to download UltraDES.dll from NuGet and no bundled fallback exists. "
+                        "Set ULTRADES_NUGET_VERSION to a known version or provide ultrades/UltraDES.dll."
+                    ) from exc
+                self.announce(
+                    f"Warning: could not download UltraDES from NuGet ({exc}); using bundled {destination}",
+                    level=3,
+                )
+        super().run()
+
+
+with open("README.md", "r", encoding="utf-8") as fh:
     long_description = fh.read()
 
-# Caminho para os dados do arquivo a serem incluídos no pacote
-data_files_path = os.path.join("lib", "site-packages")
-dll_path = os.path.join("ultrades", "UltraDES.dll")
-
 setuptools.setup(
-    # Informações básicas
     name="ultrades-python",
     version="0.0.6",
     author="LACSED Developers",
     author_email="lacsed.ufmg@gmail.com",
     description="A library for analysis and control of Discrete Event Systems",
-    
-    # Descrição longa e seu tipo
     long_description=long_description,
     long_description_content_type="text/markdown",
-    
-    # Link para o repositório do projeto
     url="https://github.com/lacsed/ultrades",
-    
-    # Encontra todos os pacotes no diretório atual
     packages=setuptools.find_packages(),
-    
-    # Classificadores para informar sobre o tipo de pacote
     classifiers=[
         "Programming Language :: Python :: 3",
         "License :: OSI Approved :: MIT License",
         "Operating System :: OS Independent",
     ],
-    
-    # Dependências necessárias
     install_requires=[
-        'pycparser',
-        'pythonnet>=2.5.0',
-        'ipython'
+        "pycparser",
+        "pythonnet>=3.0.0",
+        "ipython",
     ],
-    
-    # Arquivos de dados a serem incluídos no pacote
-    data_files=[(data_files_path, [dll_path])],
-
-    package_data={"ultrades": ["*.dll"],},
+    package_data={"ultrades": [ASSEMBLY_NAME]},
     include_package_data=True,
-    
-    # Versão mínima do Python necessária
-    python_requires='>=3.6',
+    cmdclass={"build_py": build_py},
+    python_requires=">=3.8",
 )

--- a/ultrades/__init__.py
+++ b/ultrades/__init__.py
@@ -2,23 +2,40 @@
 from __future__ import annotations
 
 import os
+from pathlib import Path
+import sys
 from typing import Optional
-import sys, ultrades, os
-sys.path.append(os.path.dirname(ultrades.__file__))
 
 _RUNTIME_ENV_VAR = "ULTRADES_RUNTIME"
+_PACKAGE_DIR = Path(__file__).resolve().parent
+_ULTRADES_DLL = _PACKAGE_DIR / "UltraDES.dll"
+_DLL_DIRECTORY_HANDLE = None
+
+
+def _add_package_dir_to_loader_path() -> None:
+    """Make the packaged .NET assembly discoverable on Windows, macOS and Linux."""
+
+    global _DLL_DIRECTORY_HANDLE
+    package_dir = str(_PACKAGE_DIR)
+    if package_dir not in sys.path:
+        sys.path.append(package_dir)
+
+    # Python 3.8+ on Windows no longer searches PATH for DLL dependencies.
+    # Keeping this handle alive preserves the directory for the process.
+    if os.name == "nt" and hasattr(os, "add_dll_directory"):
+        _DLL_DIRECTORY_HANDLE = os.add_dll_directory(package_dir)
 
 
 def _load_pythonnet_runtime() -> None:
     """Ensure the pythonnet runtime is loaded.
 
-    The package historically relied on Mono being available. When running on
-    environments such as Google Colab Mono is usually absent and pythonnet must
-    be explicitly instructed to use the ``coreclr`` runtime.  This helper tries
-    to import :mod:`clr` directly, loading Mono by default when available.  If
-    the import fails we progressively fall back to ``mono`` and then ``coreclr``
-    using :func:`pythonnet.load`.
+    ``ULTRADES_RUNTIME`` can force a pythonnet runtime (for example ``coreclr``
+    in Google Colab/Jupyter images or ``mono`` on older Unix installations).
+    Without an explicit preference we try the default import first, then Mono,
+    then CoreCLR so notebooks on Windows, macOS and Linux get a useful fallback.
     """
+
+    _add_package_dir_to_loader_path()
 
     try:
         import clr  # type: ignore  # noqa: F401 - imported for its side effect
@@ -33,9 +50,6 @@ def _load_pythonnet_runtime() -> None:
 
     runtime_preference: Optional[str] = os.environ.get(_RUNTIME_ENV_VAR)
     runtime_candidates = [runtime_preference] if runtime_preference else []
-
-    # First try Mono (the historical dependency).  If it fails we attempt
-    # CoreCLR which is available on platforms such as Google Colab.
     runtime_candidates.extend(["mono", "coreclr"])
 
     last_error: Optional[Exception] = None
@@ -49,14 +63,30 @@ def _load_pythonnet_runtime() -> None:
             last_error = exc
     else:
         raise RuntimeError(
-            "Unable to load a pythonnet runtime. Last error: %s" % last_error
+            "Unable to load a pythonnet runtime. Set ULTRADES_RUNTIME=coreclr or "
+            f"ULTRADES_RUNTIME=mono to choose one explicitly. Last error: {last_error}"
         )
 
-    # Import clr after a runtime has been loaded so it is available for the
-    # rest of the package.
     import clr  # type: ignore  # noqa: F401
+
+
+def add_ultrades_reference() -> None:
+    """Load the packaged UltraDES assembly with an absolute-path fallback."""
+
+    _add_package_dir_to_loader_path()
+    import clr  # type: ignore
+
+    try:
+        clr.AddReference("UltraDES")
+    except Exception:
+        if not _ULTRADES_DLL.exists():
+            raise FileNotFoundError(
+                f"UltraDES assembly not found at {_ULTRADES_DLL}. Reinstall the package "
+                "or build it with network access so setup.py can fetch the NuGet package."
+            )
+        clr.AddReference(str(_ULTRADES_DLL))
 
 
 _load_pythonnet_runtime()
 
-__all__ = ["automata", "petrinets"]
+__all__ = ["add_ultrades_reference", "automata", "petrinets"]

--- a/ultrades/automata.py
+++ b/ultrades/automata.py
@@ -1,5 +1,6 @@
 import clr
-clr.AddReference("UltraDES")
+from ultrades import add_ultrades_reference
+add_ultrades_reference()
 clr.AddReference("System.Linq")
 clr.AddReference('System.Collections')
 

--- a/ultrades/petrinets.py
+++ b/ultrades/petrinets.py
@@ -1,5 +1,6 @@
 import clr
-clr.AddReference("UltraDES")
+from ultrades import add_ultrades_reference
+add_ultrades_reference()
 clr.AddReference("System.Linq")
 clr.AddReference('System.Collections')
 

--- a/ultrades_python.egg-info/PKG-INFO
+++ b/ultrades_python.egg-info/PKG-INFO
@@ -1,4 +1,4 @@
-Metadata-Version: 2.1
+Metadata-Version: 2.4
 Name: ultrades-python
 Version: 0.0.6
 Summary: A library for analysis and control of Discrete Event Systems
@@ -8,12 +8,22 @@ Author-email: lacsed.ufmg@gmail.com
 Classifier: Programming Language :: Python :: 3
 Classifier: License :: OSI Approved :: MIT License
 Classifier: Operating System :: OS Independent
-Requires-Python: >=3.6
+Requires-Python: >=3.8
 Description-Content-Type: text/markdown
 License-File: LICENSE
 Requires-Dist: pycparser
-Requires-Dist: pythonnet>=2.5.0
+Requires-Dist: pythonnet>=3.0.0
 Requires-Dist: ipython
+Dynamic: author
+Dynamic: author-email
+Dynamic: classifier
+Dynamic: description
+Dynamic: description-content-type
+Dynamic: home-page
+Dynamic: license-file
+Dynamic: requires-dist
+Dynamic: requires-python
+Dynamic: summary
 
 <p align="center">
   <a href="https://github.com/lacsed/UltraDES">

--- a/ultrades_python.egg-info/requires.txt
+++ b/ultrades_python.egg-info/requires.txt
@@ -1,3 +1,3 @@
 pycparser
-pythonnet>=2.5.0
+pythonnet>=3.0.0
 ipython


### PR DESCRIPTION
### Motivation
- Tornar a instalação e uso do wrapper UltraDES mais robusta em Windows, macOS, Linux, Jupyter e Colab, e permitir obter a versão mais recente do assembly gerenciado em vez de depender apenas de um DLL empacotado.
- Fornecer comportamento previsível em ambientes sem rede ou em notebooks, com opções para forçar runtime e controlar o download via variáveis de ambiente.

### Description
- Substitui o `setup.py` por um instalador que consulta o NuGet flat container, escolhe a versão mais recente (ou a version especificada via `ULTRADES_NUGET_VERSION`) e extrai o `UltraDES.dll` do `.nupkg` mais portátil, com fallback para o DLL empacotado; o comportamento pode ser desativado com `ULTRADES_SKIP_NUGET_DOWNLOAD` e o pacote alvo pode ser alterado com `ULTRADES_NUGET_PACKAGE`.
- Adiciona um `build_py` customizado que baixa/extrai o assembly antes do build e altera o empacotamento para incluir `UltraDES.dll` como `package_data` em vez de `data_files`.
- Atualiza as exigências e compatibilidade para `pythonnet>=3.0.0` e `python_requires=">=3.8"` e ajusta os metadados gerados (`ultrades_python.egg-info`).
- Melhora `ultrades/__init__.py` para tornar o diretório do pacote descobrível por loaders (.NET/CLR), expõe `add_ultrades_reference()` que tenta `clr.AddReference("UltraDES")` e, em caso de falha, usa o caminho absoluto para o DLL empacotado; os módulos `automata` e `petrinets` agora chamam `add_ultrades_reference()` antes de registrar referências .NET.

### Testing
- `python -m py_compile setup.py ultrades/__init__.py ultrades/automata.py ultrades/petrinets.py` — compilação estática dos módulos concluída com sucesso.
- `ULTRADES_SKIP_NUGET_DOWNLOAD=1 python setup.py build_py` — build executado com sucesso usando o DLL empacotado como fallback.
- `python setup.py build_py` — build executado com sucesso (tentativa de download ocorreu quando disponível; em ambientes sem rede o fallback empacotado foi usado).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5136cafb68832ca72adac7faf6ea93)