### PR TITLE
Make UltraDES Python state/event/transition types facades over C# objects

### DIFF
--- a/ultrades/automata.py
+++ b/ultrades/automata.py
@@ -30,6 +30,9 @@ import hashlib
 def _as_event(event_like, event_source):
     """Return the C# ``Event`` instance for ``event_like``."""
 
+    if isinstance(event_like, PythonEvent):
+        return event_like._to_csharp()
+
     if isinstance(event_like, AbstractEvent):
         return event_like
 
@@ -51,6 +54,9 @@ def _as_event(event_like, event_source):
 
 def _as_state(state_like, state_source):
     """Return the C# ``State`` instance for ``state_like``."""
+
+    if isinstance(state_like, PythonState):
+        return state_like._to_csharp()
 
     if isinstance(state_like, State):
         return state_like
@@ -82,7 +88,9 @@ def _to_event_hashset(events, event_source=None):
     hashset = HashSet[AbstractEvent]()
     for event in events:
         if event_source is None:
-            if isinstance(event, AbstractEvent):
+            if isinstance(event, PythonEvent):
+                hashset.Add(event._to_csharp())
+            elif isinstance(event, AbstractEvent):
                 hashset.Add(event)
             else:
                 raise TypeError(
@@ -98,7 +106,9 @@ def _to_state_list(states, state_source=None):
     state_list = List[State]()
     for state in states:
         if state_source is None:
-            if isinstance(state, State):
+            if isinstance(state, PythonState):
+                state_list.Add(state._to_csharp())
+            elif isinstance(state, State):
                 state_list.Add(state)
             else:
                 raise TypeError(
@@ -115,9 +125,11 @@ def _to_state_tuple_list(pairs, state_source=None):
     tuple_list = List[ValueTuple[State, State]]()
     for origin, destination in pairs:
         if state_source is None:
-            if isinstance(origin, State) and isinstance(destination, State):
-                resolved_origin = origin
-                resolved_destination = destination
+            if isinstance(origin, (PythonState, State)) and isinstance(
+                destination, (PythonState, State)
+            ):
+                resolved_origin = _convert_state_to_csharp(origin)
+                resolved_destination = _convert_state_to_csharp(destination)
             else:
                 raise TypeError(
                     "State pairs must contain UltraDES states when no automaton context is provided."
@@ -140,168 +152,203 @@ def load_viz_js():
 load_viz_js()
 
 
-# === Python wrapper types with transparent C# conversion ===
+# === Python facade types with transparent C# conversion ===
 class PythonEvent:
-    """Python wrapper for UltraDES Event with transparent C# conversion."""
-    
+    """Python facade for an UltraDES C# ``Event``.
+
+    The facade keeps the original C# object internally, exposes Python-friendly
+    attributes and renders the event by name when printed.
+    """
+
     def __init__(self, name, controllable=True):
-        """Create a Python Event.
-        
-        Args:
-            name: Event name (string)
-            controllable: Boolean indicating if event is controllable (default: True)
-        """
-        self.name = name
-        self.controllable = controllable
-        self._csharp_event = None
-    
-    def _to_csharp(self):
-        """Convert to C# Event (cached)."""
-        if self._csharp_event is None:
+        if isinstance(name, PythonEvent):
+            self._csharp_event = name._to_csharp()
+        elif isinstance(name, AbstractEvent):
+            self._csharp_event = name
+        else:
             self._csharp_event = Event(
-                self.name,
-                Controllability.Controllable if self.controllable else Controllability.Uncontrollable
+                str(name),
+                Controllability.Controllable
+                if controllable
+                else Controllability.Uncontrollable,
             )
+
+    @property
+    def name(self):
+        return self._csharp_event.Name
+
+    @property
+    def controllable(self):
+        return self._csharp_event.Controllability == Controllability.Controllable
+
+    def _to_csharp(self):
         return self._csharp_event
-    
+
+    def __getattr__(self, name):
+        return getattr(self._csharp_event, name)
+
     def __repr__(self):
         ctrl = "controllable" if self.controllable else "uncontrollable"
         return f"Event('{self.name}', {ctrl})"
-    
+
     def __str__(self):
         return self.name
+
+    def __eq__(self, other):
+        return self._to_csharp().Equals(_convert_event_to_csharp(other))
+
+    def __hash__(self):
+        return self._to_csharp().GetHashCode()
 
 
 class PythonState:
-    """Python wrapper for UltraDES State with transparent C# conversion."""
-    
+    """Python facade for an UltraDES C# ``State``."""
+
     def __init__(self, name, marked=False):
-        """Create a Python State.
-        
-        Args:
-            name: State name (string)
-            marked: Boolean indicating if state is marked (default: False)
-        """
-        self.name = name
-        self.marked = marked
-        self._csharp_state = None
-    
-    def _to_csharp(self):
-        """Convert to C# State (cached)."""
-        if self._csharp_state is None:
+        if isinstance(name, PythonState):
+            self._csharp_state = name._to_csharp()
+        elif isinstance(name, State):
+            self._csharp_state = name
+        else:
             self._csharp_state = State(
-                self.name,
-                Marking.Marked if self.marked else Marking.Unmarked
+                str(name), Marking.Marked if marked else Marking.Unmarked
             )
+
+    @property
+    def name(self):
+        return self._csharp_state.Name
+
+    @property
+    def marked(self):
+        return self._csharp_state.Marking == Marking.Marked
+
+    def _to_csharp(self):
         return self._csharp_state
-    
+
+    def __getattr__(self, name):
+        return getattr(self._csharp_state, name)
+
     def __repr__(self):
         mark = "marked" if self.marked else "unmarked"
         return f"State('{self.name}', {mark})"
-    
+
     def __str__(self):
         return self.name
 
+    def __eq__(self, other):
+        return self._to_csharp().Equals(_convert_state_to_csharp(other))
+
+    def __hash__(self):
+        return self._to_csharp().GetHashCode()
+
 
 class PythonTransition:
-    """Python wrapper for UltraDES Transition with transparent C# conversion."""
-    
-    def __init__(self, origin, trigger, destination):
-        """Create a Python Transition.
-        
-        Args:
-            origin: Origin state (PythonState or State)
-            trigger: Triggering event (PythonEvent or Event)
-            destination: Destination state (PythonState or State)
-        """
-        self.origin = origin
-        self.trigger = trigger
-        self.destination = destination
-    
+    """Python facade for an UltraDES C# ``Transition``."""
+
+    def __init__(self, origin, trigger=None, destination=None):
+        if trigger is None and destination is None:
+            if isinstance(origin, PythonTransition):
+                self._csharp_transition = origin._to_csharp()
+            elif isinstance(origin, Transition):
+                self._csharp_transition = origin
+            else:
+                raise TypeError(
+                    "A transition facade needs either a Transition or "
+                    "(origin, trigger, destination)."
+                )
+        else:
+            self._csharp_transition = Transition(
+                _convert_state_to_csharp(origin),
+                _convert_event_to_csharp(trigger),
+                _convert_state_to_csharp(destination),
+            )
+
+    @property
+    def origin(self):
+        return PythonState(self._csharp_transition.Origin)
+
+    @property
+    def trigger(self):
+        return PythonEvent(self._csharp_transition.Trigger)
+
+    @property
+    def destination(self):
+        return PythonState(self._csharp_transition.Destination)
+
     def _to_csharp(self):
-        """Convert to C# Transition."""
-        origin = self.origin._to_csharp() if isinstance(self.origin, PythonState) else self.origin
-        trigger = self.trigger._to_csharp() if isinstance(self.trigger, PythonEvent) else self.trigger
-        destination = self.destination._to_csharp() if isinstance(self.destination, PythonState) else self.destination
-        return Transition(origin, trigger, destination)
-    
+        return self._csharp_transition
+
+    def __getattr__(self, name):
+        return getattr(self._csharp_transition, name)
+
     def __repr__(self):
-        return f"PythonTransition({self.origin} --{self.trigger}--> {self.destination})"
+        return f"Transition({self.origin} --{self.trigger}--> {self.destination})"
+
+    def __str__(self):
+        return f"{self.origin} --{self.trigger}--> {self.destination}"
+
+    def __eq__(self, other):
+        return self._to_csharp().Equals(_convert_transition_to_csharp(other))
+
+    def __hash__(self):
+        return self._to_csharp().GetHashCode()
 
 
 def _convert_event_to_csharp(event_obj):
-    """Convert Event to C# Event if needed."""
+    """Convert a Python/C# event facade to the underlying C# Event."""
     if isinstance(event_obj, PythonEvent):
         return event_obj._to_csharp()
     return event_obj
 
 
 def _convert_state_to_csharp(state_obj):
-    """Convert State to C# State if needed."""
+    """Convert a Python/C# state facade to the underlying C# State."""
     if isinstance(state_obj, PythonState):
         return state_obj._to_csharp()
     return state_obj
 
 
 def _convert_transition_to_csharp(transition_obj):
-    """Convert Transition to C# Transition if needed."""
+    """Convert a Python/C# transition facade to the underlying C# Transition."""
     if isinstance(transition_obj, PythonTransition):
         return transition_obj._to_csharp()
     return transition_obj
 
 
+def _wrap_event(event_obj):
+    return event_obj if isinstance(event_obj, PythonEvent) else PythonEvent(event_obj)
+
+
+def _wrap_state(state_obj):
+    return state_obj if isinstance(state_obj, PythonState) else PythonState(state_obj)
+
+
+def _wrap_transition(transition_obj):
+    return (
+        transition_obj
+        if isinstance(transition_obj, PythonTransition)
+        else PythonTransition(transition_obj)
+    )
+
+
 def state(name, marked=False):
-    """Create a Python State (new easy-to-use type).
-    
-    Args:
-        name: State name (string)
-        marked: Boolean indicating if state is marked (default: False)
-    
-    Returns:
-        PythonState: A Python wrapper state that converts transparently to C#
-    """
+    """Create or wrap a Python state facade."""
     return PythonState(name, marked)
 
 
 def is_marked(q):
-    """Check if a state is marked.
-    
-    Args:
-        q: State (PythonState or C# State)
-    
-    Returns:
-        Boolean: True if marked, False otherwise
-    """
-    if isinstance(q, PythonState):
-        return q.marked
-    return q.Marking == Marking.Marked
+    """Check if a Python or C# state is marked."""
+    return _convert_state_to_csharp(q).Marking == Marking.Marked
 
 
 def event(name, controllable=True):
-    """Create a Python Event (new easy-to-use type).
-    
-    Args:
-        name: Event name (string)
-        controllable: Boolean indicating if event is controllable (default: True)
-    
-    Returns:
-        PythonEvent: A Python wrapper event that converts transparently to C#
-    """
+    """Create or wrap a Python event facade."""
     return PythonEvent(name, controllable)
 
 
 def is_controllable(e):
-    """Check if an event is controllable.
-    
-    Args:
-        e: Event (PythonEvent or C# Event)
-    
-    Returns:
-        Boolean: True if controllable, False otherwise
-    """
-    if isinstance(e, PythonEvent):
-        return e.controllable
-    return e.Controllability == Controllability.Controllable
+    """Check if a Python or C# event is controllable."""
+    return _convert_event_to_csharp(e).Controllability == Controllability.Controllable
 
 # Automaton
 def dfa(transitions, initial, name):
@@ -336,25 +383,24 @@ def dfa(transitions, initial, name):
             trans.Add(Transition(origin_csharp, event_csharp, destination_csharp))
         else:
             # Assume it's a C# Transition
-            trans.Add(t)
+            trans.Add(_convert_transition_to_csharp(t))
     
     return DeterministicFiniteAutomaton(trans, initial_csharp, name)
 
 def initial_state(G):
-    return G.InitialState
+    return _wrap_state(G.InitialState)
 
 def events(G):
-    return list(G.Events)
+    return [_wrap_event(e) for e in G.Events]
 
 def states(G):
-    return list(G.States)
+    return [_wrap_state(q) for q in G.States]
 
 def marked_states(G):
-    return list(G.MarkedStates)
+    return [_wrap_state(q) for q in G.MarkedStates]
 
 def transitions(G):
-    trans = G.Transitions
-    return list(map(lambda t: (t.Origin, t.Trigger, t.Destination), trans))
+    return [_wrap_transition(t) for t in G.Transitions]
 
 def simplify_states_name(G):
     return G.SimplifyStatesName()


### PR DESCRIPTION
### Motivation
- Provide Python-friendly facades for `State`, `Event` and `Transition` that keep an internal C# UltraDES object while exposing intuitive `str`/`repr` and Pythonic attributes. 
- Preserve backward compatibility so Python API functions accept mixed inputs (Python facades or raw C# objects) and continue to interoperate with existing C#-based code. 

### Description
- Reworked `PythonEvent`, `PythonState` and `PythonTransition` into facade classes that store the underlying C# object (`_csharp_event`, `_csharp_state`, `_csharp_transition`) and expose `name`/`marked`/`controllable` properties, `__str__`/`__repr__`, `__getattr__` delegation, and `__eq__`/`__hash__` that rely on the C# objects. 
- Updated conversion helpers (`_convert_*`, `_as_*`, `_to_*` helpers) to accept either facades or native C# objects and to convert appropriately when building C# collections. 
- Added wrapper helpers (`_wrap_event`, `_wrap_state`, `_wrap_transition`) and changed public APIs so `initial_state()`, `events()`, `states()`, `marked_states()`, and `transitions()` return Python facades instead of raw C# objects. 
- Made `dfa()` and related construction functions accept mixed transition formats (facades, tuples or C# transitions) and convert them to the correct C# types before creating the `DeterministicFiniteAutomaton`. 

### Testing
- Ran `python -m py_compile ultrades/automata.py`, which succeeded. 
- Ran `python test_python_types.py`, which could not complete because the environment lacks the `pythonnet` dependency (automated test blocked).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a53822d0e98832caf3130f0c46ef863)