### PR TITLE
Improve pythonnet interop and visualization loading; add packaging metadata and tests

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,3 @@
+include README.md
+include LICENSE
+include ultrades/UltraDES.dll

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools>=61", "wheel"]
+build-backend = "setuptools.build_meta"

--- a/setup.py
+++ b/setup.py
@@ -148,13 +148,13 @@ setuptools.setup(
     author="LACSED Developers",
     author_email="lacsed.ufmg@gmail.com",
     description="A library for analysis and control of Discrete Event Systems",
+    license="MIT",
     long_description=long_description,
     long_description_content_type="text/markdown",
     url="https://github.com/lacsed/ultrades",
     packages=setuptools.find_packages(),
     classifiers=[
         "Programming Language :: Python :: 3",
-        "License :: OSI Approved :: MIT License",
         "Operating System :: OS Independent",
     ],
     install_requires=[

--- a/test_python_types.py
+++ b/test_python_types.py
@@ -5,7 +5,8 @@ Test file to validate Python types and new function signatures.
 from ultrades.automata import (
     state, event, PythonTransition, PythonEvent, PythonState,
     dfa, parallel_composition, product,
-    is_marked, is_controllable
+    is_marked, is_controllable,
+    initial_state, events, states, marked_states, projection
 )
 
 
@@ -88,6 +89,12 @@ def test_dfa_with_python_types():
     print(f"DFA created: {G}")
     print(f"Initial state: {G.InitialState}")
     print(f"Number of states: {len(list(G.States))}")
+    print(f"Wrapped initial state: {initial_state(G)}")
+    print(f"Wrapped states: {states(G)}")
+    print(f"Wrapped events: {events(G)}")
+    print(f"Wrapped marked states: {marked_states(G)}")
+    projected = projection(G, a)
+    print(f"Projection with a single Python event: {projected}")
 
 
 def test_parallel_composition_list():

--- a/tests/test_automata_basic.py
+++ b/tests/test_automata_basic.py
@@ -1,0 +1,90 @@
+from ultrades.automata import (
+    accessible,
+    dfa,
+    event,
+    events,
+    initial_state,
+    inverse_projection,
+    is_controllable,
+    is_marked,
+    marked_states,
+    observer_property_verify,
+    parallel_composition,
+    product,
+    projection,
+    state,
+    states,
+    transitions,
+)
+
+
+def _two_state_automaton(name="G"):
+    s1 = state("s1", marked=True)
+    s2 = state("s2", marked=False)
+    e1 = event("e1", controllable=True)
+    e2 = event("e2", controllable=False)
+    return dfa([(s1, e1, s2), (s2, e2, s1)], s1, name), s1, s2, e1, e2
+
+
+def test_state_and_event_flags():
+    marked = state("marked", marked=True)
+    unmarked = state("unmarked", marked=False)
+    controllable = event("controllable", controllable=True)
+    uncontrollable = event("uncontrollable", controllable=False)
+
+    assert is_marked(marked) is True
+    assert is_marked(unmarked) is False
+    assert is_controllable(controllable) is True
+    assert is_controllable(uncontrollable) is False
+
+
+def test_dfa_accessors_return_expected_counts_and_wrappers():
+    automaton, s1, _s2, e1, e2 = _two_state_automaton()
+
+    assert str(initial_state(automaton)) == str(s1)
+    assert {str(q) for q in states(automaton)} == {"s1", "s2"}
+    assert {str(e) for e in events(automaton)} == {"e1", "e2"}
+    assert [str(q) for q in marked_states(automaton)] == ["s1"]
+    assert {(str(t[0]), str(t[1]), str(t[2])) for t in transitions(automaton)} == {
+        ("s1", "e1", "s2"),
+        ("s2", "e2", "s1"),
+    }
+    assert is_controllable(e1) is True
+    assert is_controllable(e2) is False
+
+
+def test_projection_accepts_single_event_and_event_list():
+    automaton, _s1, _s2, e1, e2 = _two_state_automaton()
+
+    projected_single = projection(automaton, e1)
+    projected_list = projection(automaton, [e1])
+    inverse = inverse_projection(projected_single, [e2])
+
+    assert len(states(projected_single)) >= 1
+    assert len(states(projected_list)) == len(states(projected_single))
+    assert "e2" in {str(e) for e in events(inverse)}
+
+
+def test_parallel_composition_and_product_counts():
+    g1, s1, s2, _e1, _e2 = _two_state_automaton("G1")
+    e3 = event("e3", controllable=True)
+    e4 = event("e4", controllable=False)
+    g2 = dfa([(s1, e3, s2), (s2, e4, s1)], s1, "G2")
+
+    composed = parallel_composition(g1, g2)
+    multiplied = product(g1, composed)
+
+    assert len(states(composed)) == 4
+    assert len(transitions(composed)) == 8
+    assert len(states(multiplied)) >= 1
+
+
+def test_accessible_and_observer_property_smoke():
+    automaton, _s1, _s2, e1, _e2 = _two_state_automaton()
+
+    accessible_part = accessible(automaton)
+    observer_ok, observer = observer_property_verify(automaton, [e1])
+
+    assert len(states(accessible_part)) == 2
+    assert isinstance(observer_ok, bool)
+    assert len(states(observer)) >= 1

--- a/tests/test_automata_io.py
+++ b/tests/test_automata_io.py
@@ -1,0 +1,42 @@
+from ultrades.automata import dfa, event, read_ads, read_fsm, read_xml, state, states, transitions, write_ads, write_fsm, write_xml
+
+
+def _automaton():
+    s1 = state("s1", marked=True)
+    s2 = state("s2", marked=False)
+    e1 = event("e1", controllable=True)
+    e2 = event("e2", controllable=False)
+    return dfa([(s1, e1, s2), (s2, e2, s1)], s1, "G1")
+
+
+def test_ads_roundtrip_preserves_counts(tmp_path):
+    path = tmp_path / "g1.ads"
+    automaton = _automaton()
+
+    write_ads(automaton, str(path))
+    loaded = read_ads(str(path))
+
+    assert len(states(loaded)) == 2
+    assert len(transitions(loaded)) == 2
+
+
+def test_fsm_roundtrip_preserves_counts(tmp_path):
+    path = tmp_path / "g1.fsm"
+    automaton = _automaton()
+
+    write_fsm(automaton, str(path))
+    loaded = read_fsm(str(path))
+
+    assert len(states(loaded)) == 2
+    assert len(transitions(loaded)) == 2
+
+
+def test_xml_roundtrip_preserves_counts(tmp_path):
+    path = tmp_path / "g1.xml"
+    automaton = _automaton()
+
+    write_xml(automaton, str(path))
+    loaded = read_xml(str(path))
+
+    assert len(states(loaded)) == 2
+    assert len(transitions(loaded)) == 2

--- a/tests/test_display_helpers.py
+++ b/tests/test_display_helpers.py
@@ -1,0 +1,29 @@
+from IPython.display import Javascript
+
+from ultrades.automata import dfa, event, show_automaton, state
+import ultrades.petrinets as pn
+
+
+def test_show_automaton_returns_javascript_outside_ipython_shell():
+    s1 = state("s1", marked=True)
+    s2 = state("s2")
+    e1 = event("e1")
+    automaton = dfa([(s1, e1, s2)], s1, "G")
+
+    rendered = show_automaton(automaton)
+
+    assert isinstance(rendered, Javascript)
+    assert "script.onload" in rendered.data
+    assert "renderAutomaton" in rendered.data
+
+
+def test_show_petri_net_returns_javascript_outside_ipython_shell():
+    p1 = pn.place("p1")
+    t1 = pn.transition("t1")
+    net = pn.petri_net([(p1, t1, 1)], "P")
+
+    rendered = pn.show_petri_net(net)
+
+    assert isinstance(rendered, Javascript)
+    assert "script.onload" in rendered.data
+    assert "renderPetriNet" in rendered.data

--- a/tests/test_packaging.py
+++ b/tests/test_packaging.py
@@ -1,0 +1,12 @@
+from pathlib import Path
+
+
+def test_packaging_declares_modern_build_backend_and_dll_manifest():
+    pyproject = Path("pyproject.toml").read_text(encoding="utf-8")
+    manifest = Path("MANIFEST.in").read_text(encoding="utf-8")
+    setup_py = Path("setup.py").read_text(encoding="utf-8")
+
+    assert "setuptools.build_meta" in pyproject
+    assert "include ultrades/UltraDES.dll" in manifest
+    assert 'license="MIT"' in setup_py
+    assert 'package_data={"ultrades": [ASSEMBLY_NAME]}' in setup_py

--- a/tests/test_petrinets_basic.py
+++ b/tests/test_petrinets_basic.py
@@ -1,0 +1,48 @@
+import ultrades.petrinets as pn
+
+
+def _net():
+    p1 = pn.place("p1")
+    p2 = pn.place("p2")
+    p3 = pn.place("p3")
+    p4 = pn.place("p4")
+    t1 = pn.transition("t1")
+    t2 = pn.transition("t2")
+    t3 = pn.transition("t3")
+    net = pn.petri_net(
+        [
+            (t1, p4, 1),
+            (t3, p1, 2),
+            (t3, p4, 1),
+            (t2, p1, 1),
+            (p1, t1, 1),
+            (p2, t2, 1),
+            (p3, t3, 2),
+        ],
+        "P",
+    )
+    marking = pn.marking([(p1, 2), (p2, 3), (p3, 0), (p4, 1)])
+    return net, marking, (p1, p2, p3, p4), (t1, t2, t3)
+
+
+def test_petri_net_basic_counts_and_weights():
+    net, _marking, (p1, _p2, _p3, p4), (t1, _t2, t3) = _net()
+
+    assert len(pn.places(net)) == 4
+    assert len(pn.transitions(net)) == 3
+    assert len(pn.arcs(net)) == 7
+    assert len(pn.inputs(net, p4)) == 2
+    assert len(pn.outputs(net, p1)) == 1
+    assert pn.weight(net, p1, t1) == 1
+    assert pn.weight(net, t3, p1) == 2
+
+
+def test_enabled_and_fire_transition():
+    net, marking, (_p1, _p2, _p3, _p4), (t1, _t2, _t3) = _net()
+
+    enabled = pn.enabled_transitions(net, marking)
+    fired = pn.fire_transition(net, marking, t1)
+
+    assert len(enabled) == 2
+    assert "p1: 1" in str(fired)
+    assert "p4: 2" in str(fired)

--- a/tests/test_runtime_loading.py
+++ b/tests/test_runtime_loading.py
@@ -1,0 +1,7 @@
+from pythonnet import get_runtime_info
+
+import ultrades  # noqa: F401 - imports package and initializes pythonnet
+
+
+def test_default_runtime_is_coreclr():
+    assert get_runtime_info().kind == "CoreCLR"

--- a/ultrades/__init__.py
+++ b/ultrades/__init__.py
@@ -29,19 +29,14 @@ def _add_package_dir_to_loader_path() -> None:
 def _load_pythonnet_runtime() -> None:
     """Ensure the pythonnet runtime is loaded.
 
-    ``ULTRADES_RUNTIME`` can force a pythonnet runtime (for example ``coreclr``
-    in Google Colab/Jupyter images or ``mono`` on older Unix installations).
-    Without an explicit preference we try the default import first, then Mono,
-    then CoreCLR so notebooks on Windows, macOS and Linux get a useful fallback.
+    ``ULTRADES_RUNTIME`` can force a pythonnet runtime (for example ``mono`` on
+    older Unix installations).  Without an explicit preference we try CoreCLR
+    first, then Mono, so notebooks on Windows, macOS and Linux get a useful
+    fallback without pythonnet defaulting to Mono on Linux.
     """
 
     _add_package_dir_to_loader_path()
-
-    try:
-        import clr  # type: ignore  # noqa: F401 - imported for its side effect
-        return
-    except ImportError:
-        pass
+    last_error: Optional[Exception] = None
 
     try:
         from pythonnet import load  # type: ignore
@@ -50,9 +45,8 @@ def _load_pythonnet_runtime() -> None:
 
     runtime_preference: Optional[str] = os.environ.get(_RUNTIME_ENV_VAR)
     runtime_candidates = [runtime_preference] if runtime_preference else []
-    runtime_candidates.extend(["mono", "coreclr"])
+    runtime_candidates.extend(["coreclr", "mono"])
 
-    last_error: Optional[Exception] = None
     for candidate in runtime_candidates:
         if not candidate:
             continue
@@ -61,6 +55,12 @@ def _load_pythonnet_runtime() -> None:
             break
         except Exception as exc:  # pragma: no cover - depends on environment
             last_error = exc
+            if "already" in str(exc).lower():
+                try:
+                    import clr  # type: ignore  # noqa: F401
+                    return
+                except Exception:
+                    pass
     else:
         raise RuntimeError(
             "Unable to load a pythonnet runtime. Set ULTRADES_RUNTIME=coreclr or "

--- a/ultrades/automata.py
+++ b/ultrades/automata.py
@@ -4,7 +4,7 @@ add_ultrades_reference()
 clr.AddReference("System.Linq")
 clr.AddReference('System.Collections')
 
-from System import ValueTuple
+from System import Array, ValueTuple
 from System.Collections.Generic import HashSet, List
 
 from UltraDES import (
@@ -20,7 +20,7 @@ from UltraDES import (
 from UltraDES.Diagnosability import DiagnosticsAlgoritms
 from UltraDES.Opacity import OpacityAlgorithms
 
-from IPython.core.display import HTML, Javascript, display
+from IPython.display import HTML, Javascript, display
 from IPython.core.getipython import get_ipython
 import time
 import hashlib
@@ -42,7 +42,7 @@ def _as_event(event_like, event_source):
                 "Event names can only be resolved when an automaton is provided."
             )
         for candidate in event_source:
-            name = getattr(candidate, "Name", None)
+            name = _object_name(candidate)
             if name == event_like or str(candidate) == event_like:
                 return candidate
         raise ValueError(f"Unknown event '{event_like}'")
@@ -67,7 +67,7 @@ def _as_state(state_like, state_source):
                 "State names can only be resolved when an automaton is provided."
             )
         for candidate in state_source:
-            name = getattr(candidate, "Name", None)
+            name = _object_name(candidate)
             if name == state_like or str(candidate) == state_like:
                 return candidate
         raise ValueError(f"Unknown state '{state_like}'")
@@ -81,6 +81,40 @@ def _normalize_source(source):
     if source is None:
         return None
     return list(source)
+
+
+def _object_name(obj):
+    """Return the display name used by the bundled UltraDES assembly.
+
+    Different UltraDES.dll builds expose the textual identifier as ``Name``,
+    ``Alias`` or ``S``.  The Python facade normalizes those variants so wrappers
+    work with both old and newer C# packages.
+    """
+
+    for attribute in ("Name", "Alias", "S"):
+        if hasattr(obj, attribute):
+            return str(getattr(obj, attribute))
+    return str(obj)
+
+
+def _is_marked_state(state_obj):
+    if hasattr(state_obj, "IsMarked"):
+        return bool(state_obj.IsMarked)
+    return state_obj.Marking == Marking.Marked
+
+
+def _is_controllable_event(event_obj):
+    if hasattr(event_obj, "IsControllable"):
+        return bool(event_obj.IsControllable)
+    return event_obj.Controllability == Controllability.Controllable
+
+
+def _as_iterable(value):
+    if value is None:
+        return []
+    if isinstance(value, (PythonEvent, AbstractEvent, str)):
+        return [value]
+    return value
 
 
 def _to_event_hashset(events, event_source=None):
@@ -99,6 +133,19 @@ def _to_event_hashset(events, event_source=None):
         else:
             hashset.Add(_as_event(event, event_source))
     return hashset
+
+
+def _to_event_array(events, event_source=None):
+    event_source = _normalize_source(event_source)
+    resolved_events = []
+    for evt in _as_iterable(events):
+        if isinstance(evt, PythonEvent):
+            resolved_events.append(evt._to_csharp())
+        elif event_source is None:
+            resolved_events.append(_convert_event_to_csharp(evt))
+        else:
+            resolved_events.append(_as_event(evt, event_source))
+    return Array[AbstractEvent](resolved_events)
 
 
 def _to_state_list(states, state_source=None):
@@ -148,8 +195,6 @@ def load_viz_js():
         document.head.appendChild(script);
     """
     display(Javascript(script))
-    
-load_viz_js()
 
 
 # === Python facade types with transparent C# conversion ===
@@ -175,11 +220,11 @@ class PythonEvent:
 
     @property
     def name(self):
-        return self._csharp_event.Name
+        return _object_name(self._csharp_event)
 
     @property
     def controllable(self):
-        return self._csharp_event.Controllability == Controllability.Controllable
+        return _is_controllable_event(self._csharp_event)
 
     def _to_csharp(self):
         return self._csharp_event
@@ -216,11 +261,11 @@ class PythonState:
 
     @property
     def name(self):
-        return self._csharp_state.Name
+        return _object_name(self._csharp_state)
 
     @property
     def marked(self):
-        return self._csharp_state.Marking == Marking.Marked
+        return _is_marked_state(self._csharp_state)
 
     def _to_csharp(self):
         return self._csharp_state
@@ -287,6 +332,15 @@ class PythonTransition:
     def __str__(self):
         return f"{self.origin} --{self.trigger}--> {self.destination}"
 
+    def __iter__(self):
+        return iter((self.origin, self.trigger, self.destination))
+
+    def __len__(self):
+        return 3
+
+    def __getitem__(self, index):
+        return (self.origin, self.trigger, self.destination)[index]
+
     def __eq__(self, other):
         return self._to_csharp().Equals(_convert_transition_to_csharp(other))
 
@@ -338,7 +392,7 @@ def state(name, marked=False):
 
 def is_marked(q):
     """Check if a Python or C# state is marked."""
-    return _convert_state_to_csharp(q).Marking == Marking.Marked
+    return _is_marked_state(_convert_state_to_csharp(q))
 
 
 def event(name, controllable=True):
@@ -348,7 +402,7 @@ def event(name, controllable=True):
 
 def is_controllable(e):
     """Check if a Python or C# event is controllable."""
-    return _convert_event_to_csharp(e).Controllability == Controllability.Controllable
+    return _is_controllable_event(_convert_event_to_csharp(e))
 
 # Automaton
 def dfa(transitions, initial, name):
@@ -489,7 +543,7 @@ def projection(G, remove):
     # Convert PythonEvent to C# Event if needed
     remove_converted = HashSet[AbstractEvent]()
     if remove:
-        for evt in remove:
+        for evt in _as_iterable(remove):
             csharp_evt = _convert_event_to_csharp(evt)
             remove_converted.Add(csharp_evt)
     
@@ -509,7 +563,7 @@ def inverse_projection(G, events):
     # Convert PythonEvent to C# Event if needed
     events_converted = HashSet[AbstractEvent]()
     if events:
-        for evt in events:
+        for evt in _as_iterable(events):
             csharp_evt = _convert_event_to_csharp(evt)
             events_converted.Add(csharp_evt)
     
@@ -644,7 +698,8 @@ def write_fm(G, path):
     G.ToFM(path)
 
 def show_automaton(G):
-    shell_type = get_ipython().__class__.__name__
+    ipython = get_ipython()
+    shell_type = ipython.__class__.__name__ if ipython is not None else None
     
     if shell_type == 'Shell':
         timestamp = str(time.time())
@@ -652,11 +707,20 @@ def show_automaton(G):
         div_id = "out_" + hash_obj.hexdigest()
 
         htmlContent = f'''
-        <script src="https://github.com/mdaines/viz.js/releases/download/v1.8.1-pre.5/viz.js"></script>
         <div id="{div_id}"></div>
         <script>
             let targetDiv = document.querySelector("#{div_id}");
-            targetDiv.innerHTML = Viz(`{G.ToDotCode.replace("rankdir=TB", "rankdir=LR")}`, 'svg');
+            const renderAutomaton = () => {{
+                targetDiv.innerHTML = Viz(`{G.ToDotCode.replace("rankdir=TB", "rankdir=LR")}`, 'svg');
+            }};
+            if (typeof Viz === "undefined") {{
+                const script = document.createElement("script");
+                script.src = "https://github.com/mdaines/viz.js/releases/download/v1.8.1-pre.5/viz.js";
+                script.onload = renderAutomaton;
+                document.head.appendChild(script);
+            }} else {{
+                renderAutomaton();
+            }}
         </script>
         '''
 
@@ -670,7 +734,17 @@ def show_automaton(G):
 
         code = f'''
         let targetDiv = document.querySelector("#{div_id}");
-        targetDiv.innerHTML = Viz(`{G.ToDotCode.replace("rankdir=TB", "rankdir=LR")}`, 'svg')'''
+        const renderAutomaton = () => {{
+            targetDiv.innerHTML = Viz(`{G.ToDotCode.replace("rankdir=TB", "rankdir=LR")}`, 'svg');
+        }};
+        if (typeof Viz === "undefined") {{
+            const script = document.createElement("script");
+            script.src = "https://github.com/mdaines/viz.js/releases/download/v1.8.1-pre.5/viz.js";
+            script.onload = renderAutomaton;
+            document.head.appendChild(script);
+        }} else {{
+            renderAutomaton();
+        }}'''
 
         return Javascript(code)
 
@@ -685,15 +759,8 @@ def observer_property_verify(G, events):
     Returns:
         Tuple: (return_on_dead, determinized_observer)
     """
-    # Convert events
-    events_hashset = HashSet[AbstractEvent]()
-    for evt in events:
-        if isinstance(evt, PythonEvent):
-            events_hashset.Add(evt._to_csharp())
-        else:
-            events_hashset.Add(_as_event(evt, G.Events))
-    
-    list_opv = ObserverAlgorithms.ObserverPropertyVerify(G, events_hashset)
+    events_array = _to_event_array(events, G.Events)
+    list_opv = ObserverAlgorithms.ObserverPropertyVerify(G, events_array)
     return_on_dead = bool(list_opv[0])
     determinized_G = list_opv[1].Determinize
 
@@ -710,15 +777,8 @@ def observer_property_search(G, events):
     Returns:
         DeterministicFiniteAutomaton: The determinized observer
     """
-    # Convert events
-    events_hashset = HashSet[AbstractEvent]()
-    for evt in events:
-        if isinstance(evt, PythonEvent):
-            events_hashset.Add(evt._to_csharp())
-        else:
-            events_hashset.Add(_as_event(evt, G.Events))
-    
-    return ObserverAlgorithms.ObserverPropertySearch(G, events_hashset).Determinize
+    events_array = _to_event_array(events, G.Events)
+    return ObserverAlgorithms.ObserverPropertySearch(G, events_array).Determinize
 
 
 # Diagnostics
@@ -895,4 +955,3 @@ def k_steps_opacity(G, unobservable_events, secret_states, k):
         G, events_hashset, states_list, k
     )
     return bool(result), estimator
-

--- a/ultrades/petrinets.py
+++ b/ultrades/petrinets.py
@@ -8,7 +8,7 @@ from System.Collections.Generic import List, KeyValuePair
 from System import ValueTuple, UInt32
 
 from UltraDES.PetriNets import PetriNet, Marking, Node, Place, Transition, Arc
-from IPython.core.display import HTML, Javascript, display
+from IPython.display import HTML, Javascript, display
 from IPython.core.getipython import get_ipython
 import time
 import hashlib
@@ -20,8 +20,6 @@ def load_viz_js():
         document.head.appendChild(script);
     """
     display(Javascript(script))
-
-load_viz_js()
 
 
 def place(name):
@@ -96,7 +94,8 @@ def incidence_matrix(P):
     return P.IncidenceMatrix();  
 
 def show_petri_net(P):
-    shell_type = get_ipython().__class__.__name__
+    ipython = get_ipython()
+    shell_type = ipython.__class__.__name__ if ipython is not None else None
     
     if shell_type == 'Shell':
         timestamp = str(time.time())
@@ -104,11 +103,20 @@ def show_petri_net(P):
         div_id = "out_" + hash_obj.hexdigest()
 
         htmlContent = f'''
-        <script src="https://github.com/mdaines/viz.js/releases/download/v1.8.1-pre.5/viz.js"></script>
         <div id="{div_id}"></div>
         <script>
             let targetDiv = document.querySelector("#{div_id}");
-            targetDiv.innerHTML = Viz(`{P.ToDotCode*().replace("rankdir=TB", "rankdir=LR")}`, 'svg');
+            const renderPetriNet = () => {{
+                targetDiv.innerHTML = Viz(`{P.ToDotCode().replace("rankdir=TB", "rankdir=LR")}`, 'svg');
+            }};
+            if (typeof Viz === "undefined") {{
+                const script = document.createElement("script");
+                script.src = "https://github.com/mdaines/viz.js/releases/download/v1.8.1-pre.5/viz.js";
+                script.onload = renderPetriNet;
+                document.head.appendChild(script);
+            }} else {{
+                renderPetriNet();
+            }}
         </script>
         '''
 
@@ -122,6 +130,16 @@ def show_petri_net(P):
 
         code = f'''
         let targetDiv = document.querySelector("#{div_id}");
-        targetDiv.innerHTML = Viz(`{P.ToDotCode().replace("rankdir=TB", "rankdir=LR")}`, 'svg')'''
+        const renderPetriNet = () => {{
+            targetDiv.innerHTML = Viz(`{P.ToDotCode().replace("rankdir=TB", "rankdir=LR")}`, 'svg');
+        }};
+        if (typeof Viz === "undefined") {{
+            const script = document.createElement("script");
+            script.src = "https://github.com/mdaines/viz.js/releases/download/v1.8.1-pre.5/viz.js";
+            script.onload = renderPetriNet;
+            document.head.appendChild(script);
+        }} else {{
+            renderPetriNet();
+        }}'''
 
         return Javascript(code)

--- a/ultrades_python.egg-info/PKG-INFO
+++ b/ultrades_python.egg-info/PKG-INFO
@@ -5,8 +5,8 @@ Summary: A library for analysis and control of Discrete Event Systems
 Home-page: https://github.com/lacsed/ultrades
 Author: LACSED Developers
 Author-email: lacsed.ufmg@gmail.com
+License: MIT
 Classifier: Programming Language :: Python :: 3
-Classifier: License :: OSI Approved :: MIT License
 Classifier: Operating System :: OS Independent
 Requires-Python: >=3.8
 Description-Content-Type: text/markdown
@@ -20,6 +20,7 @@ Dynamic: classifier
 Dynamic: description
 Dynamic: description-content-type
 Dynamic: home-page
+Dynamic: license
 Dynamic: license-file
 Dynamic: requires-dist
 Dynamic: requires-python

--- a/ultrades_python.egg-info/SOURCES.txt
+++ b/ultrades_python.egg-info/SOURCES.txt
@@ -1,6 +1,14 @@
 LICENSE
+MANIFEST.in
 README.md
+pyproject.toml
 setup.py
+tests/test_automata_basic.py
+tests/test_automata_io.py
+tests/test_display_helpers.py
+tests/test_packaging.py
+tests/test_petrinets_basic.py
+tests/test_runtime_loading.py
 ultrades/UltraDES.dll
 ultrades/__init__.py
 ultrades/automata.py


### PR DESCRIPTION
### Motivation
- Make the Python façade robust to variations in the bundled UltraDES build and improve pythonnet runtime selection to prefer CoreCLR by default. 
- Avoid always injecting the Viz.js script and instead load it on-demand so visual helpers work outside interactive shells without redundant network loads. 
- Add modern packaging metadata and include the packaged DLL in the sdist, and provide automated tests to validate runtime, packaging and core API behaviors.

### Description
- Add `pyproject.toml` and `MANIFEST.in`, declare `UltraDES.dll` in the manifest, and add `license="MIT"` to `setup.py` and `PKG-INFO` to include license metadata. 
- Implement runtime improvements in `ultrades/__init__.py` to prefer `CoreCLR` before `Mono`, handle already-loaded runtime cases, and improve error messaging. 
- Update `ultrades/automata.py` to normalize object naming and feature flags across different UltraDES builds via `_object_name`, `_is_marked_state`, and `_is_controllable_event`, add `_to_event_array` and `_as_iterable` helpers, make `PythonTransition` sequence/iterable-compatible, accept single events or lists in `projection`/`inverse_projection`, and refactor observer calls to use the new array conversion. 
- Change visualization helpers in `ultrades/automata.py` and `ultrades/petrinets.py` to detect `get_ipython()` safely and to inject Viz.js only when needed, wiring `onload` hooks to render after the script has loaded. 
- Adjust IPython import locations and minor API compatibility code paths, and add many tests under `tests/` plus an expanded `test_python_types.py` verifying new wrappers and helpers. 

### Testing
- Ran the test suite with `pytest`, which executed the new `tests/` files plus `test_python_types.py` to validate automata, petri nets, IO round-trips, display helpers, packaging metadata and runtime selection, and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a53957888f8832caeabbadba4948982)